### PR TITLE
Bugfix - ValueError in  modify_channel_information method

### DIFF
--- a/twitchAPI/twitch.py
+++ b/twitchAPI/twitch.py
@@ -1545,7 +1545,7 @@ class Twitch:
                         {'broadcaster_id': broadcaster_id}, remove_none=True)
         body = {k: v for k, v in {'game_id': game_id,
                                   'broadcaster_language': broadcaster_language,
-                                  'title': title} if v is not None}
+                                  'title': title}.items() if v is not None}
         response = self.__api_patch_request(url, AuthType.USER, [AuthScope.USER_EDIT_BROADCAST], data=body)
         return response.status_code == 204
 


### PR DESCRIPTION
There is a bug with the method `modify_channel_information`

It raises with 

```python
File "O:\Documents\Code\Git\gimpybot\main.py", line 41, in on_message
    await twitch.modify_channel_information(TYLER, id, "en", title)
  File "O:\Documents\Code\Git\gimpybot\env\lib\site-packages\twitchAPI\twitch.py", line 1564, in modify_channel_information
    'title': title} if v is not None}
  File "O:\Documents\Code\Git\gimpybot\env\lib\site-packages\twitchAPI\twitch.py", line 1562, in <dictcomp>
    body = {k: v for k, v in {'game_id': game_id,
ValueError: too many values to unpack (expected 2)
```

there's a missing `.items()` call in that dict-comprehension