### PR TITLE
fix: correct get_custom_reward_redemption url

### DIFF
--- a/twitchAPI/twitch.py
+++ b/twitchAPI/twitch.py
@@ -2182,7 +2182,7 @@ class Twitch:
         if id is not None and len(id) > 50:
             raise ValueError('id can not have more than 50 entries')
 
-        url = build_url(TWITCH_API_BASE_URL + 'channel_points/custom_rewards/redemption',
+        url = build_url(TWITCH_API_BASE_URL + 'channel_points/custom_rewards/redemptions',
                         {
                             'broadcaster_id': broadcaster_id,
                             'reward_id': reward_id,


### PR DESCRIPTION
Fixes error 404 when attempting to use this method: <https://dev.twitch.tv/docs/api/reference#get-custom-reward-redemption>