### PR TITLE
Allow UserAuthenticator in server

### DIFF
--- a/twitchAPI/oauth.py
+++ b/twitchAPI/oauth.py
@@ -4,15 +4,25 @@ User OAuth Authenticator and helper functions
 ---------------------------------------------
 
 This tool is an alternative to various online services that give you a user auth token.
+It provides non-server and server options.
 
-************
-Requirements
-************
+***************************************
+Requirements for non-server environment
+***************************************
 
 Since this tool opens a browser tab for the Twitch authentication, you can only use this tool on enviroments that can
 open a browser window and render the `<twitch.tv>`__ website.
 
 For my authenticator you have to add the following URL as a "OAuth Redirect URL": :code:`http://localhost:17563`
+You can set that `here in your twitch dev dashboard <https://dev.twitch.tv/console>`__.
+
+***********************************
+Requirements for server environment
+***********************************
+
+You need the user code provided by Twitch when the user logs-in at the url returned by :code:`return_auth_url`.
+
+Create the UserAuthenticator with the URL of your webserver that will handle the redirect, and add it as a "OAuth Redirect URL"
 You can set that `here in your twitch dev dashboard <https://dev.twitch.tv/console>`__.
 
 ************
@@ -120,9 +130,9 @@ def revoke_token(client_id: str, access_token: str) -> bool:
 class UserAuthenticator:
     """Simple to use client for the Twitch User authentication flow.
 
-       :param ~twitchAPI.twitch.Twitch twitch: A twitch instance
-       :param list[~twitchAPI.types.AuthScope] scopes: List of the desired Auth scopes
-       :param bool force_verify: If this is true, the user will always be prompted for authorization by twitch,
+        :param ~twitchAPI.twitch.Twitch twitch: A twitch instance
+        :param list[~twitchAPI.types.AuthScope] scopes: List of the desired Auth scopes
+        :param bool force_verify: If this is true, the user will always be prompted for authorization by twitch,
                     |default| :code:`False`
         :param str url: The reachable URL that will be opened in the browser.
                     |default| :code:`http://localhost:17563`
@@ -241,8 +251,10 @@ class UserAuthenticator:
         """Start the user authentication flow\n
         If callback_func is not set, authenticate will wait till the authentication process finnished and then return
         the access_token and the refresh_token
+        If user_token is set, it will be used instead of launching the webserver and opening the browser
 
         :param callback_func: Function to call once the authentication finnished.
+        :param str user_token: Code obtained from twitch to request the access and refresh token.
         :return: None if callback_func is set, otherwise access_token and refresh_token
         :rtype: None or (str, str)
         """

--- a/twitchAPI/oauth.py
+++ b/twitchAPI/oauth.py
@@ -124,9 +124,9 @@ class UserAuthenticator:
        :param list[~twitchAPI.types.AuthScope] scopes: List of the desired Auth scopes
        :param bool force_verify: If this is true, the user will always be prompted for authorization by twitch,
                     |default| :code:`False`
-
-        :var str url: The reachable URL that will be opened in the browser.
+        :param str url: The reachable URL that will be opened in the browser.
                     |default| :code:`http://localhost:17563`
+
         :var int port: The port that will be used. |default| :code:`17653`
         :var str host: the host the webserver will bind to. |default| :code:`0.0.0.0`
        """
@@ -156,12 +156,14 @@ class UserAuthenticator:
     def __init__(self,
                  twitch: 'Twitch',
                  scopes: List[AuthScope],
-                 force_verify: bool = False):
+                 force_verify: bool = False,
+                 url: str = 'http://localhost:17563'):
         self.__twitch = twitch
         self.__client_id = twitch.app_id
         self.scopes = scopes
         self.force_verify = force_verify
         self.__logger = getLogger('twitchAPI.oauth')
+        self.url = url
 
     def __build_auth_url(self):
         params = {


### PR DESCRIPTION
I have added the option to use UserAuthenticator at a server, related to #62. I have tried to make changes small as possible:
- Added `url` parametter to `__init__` in order to pass redirect url to UserAthenticator (the default is still the same, so it does not break with previous versions)
- Added method `return_auth_url` to get twitch authentication url, which internally use `__build_auth_url`.
- Change `authenticate` method with an extra parameter `user_token`. 
    - If `user_token` is None (which is the default value) the method works like always, starting the http server and opening the browser. 
    - If `user_token` is provided, the method skip the http server and browser parts, making the request directly to twitch. After that, the callback is called if it was provided and if not the tokens are returned.
    
About the callback function, I have done the same that is done at `__handle_callback` calling it with the `user_token`, but from the docstring:

```
If callback_func is not set, authenticate will wait till the authentication process finnished and then return the access_token and the refresh_token

:param callback_func: Function to call once the authentication finnished.
```

For me it makes more sense that it should be called with the access and refresh token (since is when I consider the authentication has finished) but maybe we should discuss it on another issue.

How do you see this changes? Any feedback?