### PR TITLE
Changed Scope Reference for CHANNEL_MANAGE_CHAT_SETTINGS

### DIFF
--- a/twitchAPI/twitch.py
+++ b/twitchAPI/twitch.py
@@ -804,7 +804,7 @@ class Twitch:
             'subscriber_mode': subscriber_mode,
             'unique_chat_mode': unique_chat_mode
         })
-        result = self.__api_patch_request(url, AuthType.USER, [AuthScope.CHANNEL_MANAGE_CHAT_SETTINGS], body)
+        result = self.__api_patch_request(url, AuthType.USER, [AuthScope.MODERATOR_MANAGE_CHAT_SETTINGS], body)
         return result.json()
 
     def create_clip(self,

--- a/twitchAPI/twitch.py
+++ b/twitchAPI/twitch.py
@@ -753,7 +753,7 @@ class Twitch:
                              unique_chat_mode: Optional[bool] = None):
         """Updates the broadcaster’s chat settings.
 
-        Requires User authentication with scope :const:`twitchAPI.types.AuthScope.CHANNEL_MANAGE_CHAT_SETTINGS`\n
+        Requires User authentication with scope :const:`twitchAPI.types.AuthScope.MODERATOR_MANAGE_CHAT_SETTINGS`\n
         For detailed documentation, see here: https://dev.twitch.tv/docs/api/reference#update-chat-settings
 
         :param str broadcaster_id: The ID of the broadcaster whose chat settings you want to update.

--- a/twitchAPI/types.py
+++ b/twitchAPI/types.py
@@ -51,7 +51,7 @@ class AuthScope(Enum):
     CHANNEL_MANAGE_PREDICTIONS = 'channel:manage:predictions'
     MODERATOR_MANAGE_AUTOMOD = 'moderator:manage:automod'
     CHANNEL_MANAGE_SCHEDULE = 'channel:manage:schedule'
-    CHANNEL_MANAGE_CHAT_SETTINGS = 'channel:manage:chat_settings'
+    CHANNEL_MANAGE_CHAT_SETTINGS = 'moderator:manage:chat_settings'
     MODERATOR_MANAGE_BANNED_USERS = 'moderator:manage:banned_users'
     MODERATOR_READ_BLOCKED_TERMS = 'moderator:read:blocked_terms'
     MODERATOR_MANAGE_BLOCKED_TERMS = 'moderator:manage:blocked_terms'

--- a/twitchAPI/types.py
+++ b/twitchAPI/types.py
@@ -51,7 +51,7 @@ class AuthScope(Enum):
     CHANNEL_MANAGE_PREDICTIONS = 'channel:manage:predictions'
     MODERATOR_MANAGE_AUTOMOD = 'moderator:manage:automod'
     CHANNEL_MANAGE_SCHEDULE = 'channel:manage:schedule'
-    CHANNEL_MANAGE_CHAT_SETTINGS = 'moderator:manage:chat_settings'
+    MODERATOR_MANAGE_CHAT_SETTINGS = 'moderator:manage:chat_settings'
     MODERATOR_MANAGE_BANNED_USERS = 'moderator:manage:banned_users'
     MODERATOR_READ_BLOCKED_TERMS = 'moderator:read:blocked_terms'
     MODERATOR_MANAGE_BLOCKED_TERMS = 'moderator:manage:blocked_terms'


### PR DESCRIPTION
Went to change chat settings and the scope details set was incorrect.
For quick reference - https://dev.twitch.tv/docs/api/reference#update-chat-settings
