### PR TITLE
Add a check for missing scopes in set_user_authentication

### DIFF
--- a/twitchAPI/twitch.py
+++ b/twitchAPI/twitch.py
@@ -666,6 +666,8 @@ class Twitch:
             if val_result.get('client_id') != self.app_id:
                 raise InvalidTokenException('client id does not match')
             scopes = val_result.get('scopes', [])
+            if not scope:
+                raise MissingScopeException('scope was not provided or is None')
             for s in scope:
                 if s not in scopes:
                     raise MissingScopeException(f'given token is missing scope {s.value}')


### PR DESCRIPTION
If scope is not defined in set_user_authentication, a runtime error is generated rather than the expected scope exception