### PR TITLE
Set __is_closed=True when user_token is supplied to UserAuthenticator.authenticate()

### DIFF
--- a/twitchAPI/oauth.py
+++ b/twitchAPI/oauth.py
@@ -327,6 +327,7 @@ class UserAuthenticator:
             # now we need to actually get the correct token
         else:
             self.__user_token = user_token
+            self.__is_closed = True
 
         param = {
             'client_id': self.__client_id,


### PR DESCRIPTION
Addresses #174
I simply set self.__is_closed during the "user_token is set" check so other logic wasn't affected.