### PR TITLE
Allow not auto-opening browser for oauth workflow

### DIFF
--- a/twitchAPI/oauth.py
+++ b/twitchAPI/oauth.py
@@ -344,7 +344,8 @@ class UserAuthenticator:
                            callback_func: Optional[Callable[[str, str], None]] = None,
                            user_token: Optional[str] = None,
                            browser_name: Optional[str] = None,
-                           browser_new: int = 2):
+                           browser_new: int = 2,
+                           use_browser: bool = True):
         """Start the user authentication flow\n
         If callback_func is not set, authenticate will wait till the authentication process finished and then return
         the access_token and the refresh_token
@@ -358,6 +359,8 @@ class UserAuthenticator:
         :param browser_new: controls in which way the link will be opened in the browser.
                             See `the webbrowser documentation <https://docs.python.org/3/library/webbrowser.html#webbrowser.open>`__ for more info
                             |default|:code:`2`
+        :param use_browser: controls if a browser should be opened by default or if the url to authenticate via should printed to the log
+                            |default|:code: True
         :return: None if callback_func is set, otherwise access_token and refresh_token
         :raises ~twitchAPI.type.TwitchAPIException: if authentication fails
         :rtype: None or (str, str)
@@ -372,11 +375,14 @@ class UserAuthenticator:
             # wait for the server to start up
             while not self._server_running:
                 await asyncio.sleep(0.01)
-            # open in browser
-            browser = webbrowser.get(browser_name)
-            browser.open(self._build_auth_url(), new=browser_new)
-            while self._user_token is None:
-                await asyncio.sleep(0.01)
+            if use_browser:
+                # open in browser
+                browser = webbrowser.get(browser_name)
+                browser.open(self._build_auth_url(), new=browser_new)
+                while self._user_token is None:
+                    await asyncio.sleep(0.01)
+            else:
+                self.logger.info(f"To authenticate open: {self._build_auth_url()}")
             # now we need to actually get the correct token
         else:
             self._user_token = user_token

--- a/twitchAPI/oauth.py
+++ b/twitchAPI/oauth.py
@@ -379,10 +379,10 @@ class UserAuthenticator:
                 # open in browser
                 browser = webbrowser.get(browser_name)
                 browser.open(self._build_auth_url(), new=browser_new)
-                while self._user_token is None:
-                    await asyncio.sleep(0.01)
             else:
                 self.logger.info(f"To authenticate open: {self._build_auth_url()}")
+            while self._user_token is None:
+                await asyncio.sleep(0.01)
             # now we need to actually get the correct token
         else:
             self._user_token = user_token


### PR DESCRIPTION
I have multiple browser profiles and would like to manually choose which profile to open the oauth workflow in, but the auto-open browser library doesn't provide that granular level of control. Because of that I'd like to have the option to simply print the url to open to the log and then I can manually open that url in the browser tab of my choice.