### PR TITLE
Handle status code 403 in refresh_access_token(...)

### DIFF
--- a/twitchAPI/type.py
+++ b/twitchAPI/type.py
@@ -352,6 +352,11 @@ class MissingAppSecretException(TwitchAPIException):
     pass
 
 
+class InvalidAppSecretException(TwitchAPIException):
+    """When the app secret is invalid"""
+    pass
+
+
 class EventSubSubscriptionTimeout(TwitchAPIException):
     """When the waiting for a confirmed EventSub subscription timed out"""
     pass


### PR DESCRIPTION
If client secret is invalid, refresh_access_token() throws a KeyError while trying to access the data key "access_token", because the response status code 403 is handled correctly.

Implementation:
- handle invalid client secret response in refresh_access_token()
- use HttpStatus Code enums
- add custom InvalidAppSecretException class