### PR TITLE
Add message filter for shared chat from other rooms

### DIFF
--- a/twitchAPI/chat/middleware.py
+++ b/twitchAPI/chat/middleware.py
@@ -230,3 +230,16 @@ class GlobalCommandCooldown(BaseCommandMiddleware):
 
     async def was_executed(self, command: 'ChatCommand'):
         self._last_executed[command.name] = datetime.now()
+
+
+class SharedChatOnlyCurrent(BaseCommandMiddleware):
+    """Restricts commands to only current chat room in Shared Chat streams"""
+
+    async def can_execute(self, command: ChatCommand) -> bool:
+        if "source-room-id" in command._parsed["tags"]:
+            if command._parsed["tags"]["source-room-id"] != command._parsed["tags"].get("room-id"):
+                return False
+        return True
+
+    async def was_executed(self, command: ChatCommand):
+        pass


### PR DESCRIPTION
Twitch is rolling out shared chat rooms between streamers, and it can result in a bot responding to commands or messages from other chatrooms. This adds an optional (default on) filter for messages to only pay attention to the message if has a `source-room-id` that matches the current `room-id`. I'm still investigating to see if this needs to be one level higher in the stack to also handle chat events like `RAID` and `SUB`