### PR TITLE
fix: Twitch.get_emote_sets() being parsed incorrectly

### DIFF
--- a/twitchAPI/object/api.py
+++ b/twitchAPI/object/api.py
@@ -21,12 +21,12 @@ __all__ = ['TwitchUser', 'TwitchUserFollow', 'TwitchUserFollowResult', 'DateRang
            'SearchCategoryResult', 'StartCommercialResult', 'Cheermote', 'GetCheermotesResponse', 'HypeTrainContribution', 'HypeTrainEventData',
            'HypeTrainEvent', 'DropsEntitlement', 'MaxPerStreamSetting', 'MaxPerUserPerStreamSetting', 'GlobalCooldownSetting', 'CustomReward',
            'PartialCustomReward', 'CustomRewardRedemption', 'ChannelEditor', 'BlockListEntry', 'PollChoice', 'Poll', 'Predictor', 'PredictionOutcome',
-           'Prediction', 'RaidStartResult', 'ChatBadgeVersion', 'ChatBadge', 'Emote', 'UserEmote', 'GetEmotesResponse', 'EventSubSubscription',
-           'GetEventSubSubscriptionResult', 'StreamCategory', 'ChannelStreamScheduleSegment', 'StreamVacation', 'ChannelStreamSchedule',
-           'ChannelVIP', 'UserChatColor', 'Chatter', 'GetChattersResponse', 'ShieldModeStatus', 'CharityAmount', 'CharityCampaign',
-           'CharityCampaignDonation', 'AutoModSettings', 'ChannelFollower', 'ChannelFollowersResult', 'FollowedChannel', 'FollowedChannelsResult',
-           'ContentClassificationLabel', 'AdSchedule', 'AdSnoozeResponse', 'SendMessageResponse', 'ChannelModerator', 'UserEmotesResponse',
-           'WarnResponse', 'SharedChatParticipant', 'SharedChatSession']
+           'Prediction', 'RaidStartResult', 'ChatBadgeVersion', 'ChatBadge', 'Emote', 'ChannelEmote', 'UserEmote', 'GetChannelEmotesResponse',
+           'GetEmotesResponse', 'EventSubSubscription', 'GetEventSubSubscriptionResult', 'StreamCategory', 'ChannelStreamScheduleSegment',
+           'StreamVacation', 'ChannelStreamSchedule', 'ChannelVIP', 'UserChatColor', 'Chatter', 'GetChattersResponse', 'ShieldModeStatus',
+           'CharityAmount', 'CharityCampaign', 'CharityCampaignDonation', 'AutoModSettings', 'ChannelFollower', 'ChannelFollowersResult',
+           'FollowedChannel', 'FollowedChannelsResult', 'ContentClassificationLabel', 'AdSchedule', 'AdSnoozeResponse', 'SendMessageResponse',
+           'ChannelModerator', 'UserEmotesResponse', 'WarnResponse', 'SharedChatParticipant', 'SharedChatSession']
 
 
 class TwitchUser(TwitchObject):
@@ -650,7 +650,6 @@ class Emote(TwitchObject):
     id: str
     name: str
     images: Dict[str, str]
-    tier: str
     emote_type: str
     emote_set_id: str
     format: List[str]
@@ -658,8 +657,17 @@ class Emote(TwitchObject):
     theme_mode: List[str]
 
 
+class ChannelEmote(Emote):
+    tier: str
+
+
 class UserEmote(Emote):
     owner_id: str
+
+
+class GetChannelEmotesResponse(IterTwitchObject):
+    data: List[ChannelEmote]
+    template: str
 
 
 class GetEmotesResponse(IterTwitchObject):

--- a/twitchAPI/twitch.py
+++ b/twitchAPI/twitch.py
@@ -3059,7 +3059,7 @@ class Twitch:
         """
         return await self._build_result('GET', 'chat/badges/global', {}, AuthType.EITHER, [], List[ChatBadge])
 
-    async def get_channel_emotes(self, broadcaster_id: str) -> GetEmotesResponse:
+    async def get_channel_emotes(self, broadcaster_id: str) -> GetChannelEmotesResponse:
         """Gets all emotes that the specified Twitch channel created.
 
         Requires User or App Authentication\n
@@ -3105,7 +3105,7 @@ class Twitch:
         if len(emote_set_id) == 0 or len(emote_set_id) > 25:
             raise ValueError('you need to specify between 1 and 25 emote_set_ids')
         return await self._build_result('GET', 'chat/emotes/set', {'emote_set_id': emote_set_id}, AuthType.EITHER, [], GetEmotesResponse,
-                                        split_lists=True)
+                                        get_from_data=False, split_lists=True)
 
     async def create_eventsub_subscription(self,
                                            subscription_type: str,


### PR DESCRIPTION
Two fixes: 
- `Twitch.get_emote_sets()` was previously unpacking the `data` array when there is also a `template` property that needs to be provided
- "tier" is only provided as a property for emotes from the `Twitch.get_channel_emotes()` API